### PR TITLE
Source maps off initially, to match tutorial text

### DIFF
--- a/broccolijs/04-sass-preprocessing.md
+++ b/broccolijs/04-sass-preprocessing.md
@@ -57,8 +57,8 @@ const css = compileSass(
   "styles/app.scss",
   "assets/app.css",
   {
-    sourceMap: true,
-    sourceMapContents: true,
+    sourceMap: false,
+    sourceMapContents: false,
     annotation: "Sass files"
   }
 );


### PR DESCRIPTION
The text of the tutorial assumes that source maps are **not** enabled to begin with.